### PR TITLE
Improve backtests workflow and account status

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -21,13 +21,13 @@
     }
   },
   "permissions": ["storage", "tabs", "scripting"],
-  "host_permissions": ["https://veles.finance/*", "https://ru.veles.finance/*"],
+  "host_permissions": ["https://veles.finance/*", "https://ru.veles.finance/*", "https://beta.veles.finance/*"],
   "background": {
     "service_worker": "scripts/background.js"
   },
   "content_scripts": [
     {
-      "matches": ["https://veles.finance/*", "https://ru.veles.finance/*"],
+      "matches": ["https://veles.finance/*", "https://ru.veles.finance/*", "https://beta.veles.finance/*"],
       "js": ["scripts/proxy-bridge.js"],
       "run_at": "document_start"
     }
@@ -35,11 +35,11 @@
   "web_accessible_resources": [
     {
       "resources": ["scripts/page-fetch-bridge.js"],
-      "matches": ["https://veles.finance/*", "https://ru.veles.finance/*"]
+      "matches": ["https://veles.finance/*", "https://ru.veles.finance/*", "https://beta.veles.finance/*"]
     },
     {
       "resources": ["ui/dist/index.html", "ui/dist/assets/*"],
-      "matches": ["https://veles.finance/*", "https://ru.veles.finance/*"]
+      "matches": ["https://veles.finance/*", "https://ru.veles.finance/*", "https://beta.veles.finance/*"]
     }
   ]
 }

--- a/extension/ui/src/api/backtestRunner.ts
+++ b/extension/ui/src/api/backtestRunner.ts
@@ -49,6 +49,16 @@ export interface BacktestCreateResponse {
   status?: string | null;
 }
 
+export class BacktestRequestError extends Error {
+  readonly status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'BacktestRequestError';
+    this.status = status;
+  }
+}
+
 export interface SymbolDescriptor {
   base: string;
   quote: string;
@@ -79,7 +89,7 @@ export const fetchBotStrategy = async (botId: BotIdentifier): Promise<BotStrateg
 
   if (!response.ok) {
     const message = resolveProxyErrorMessage(response);
-    throw new Error(message);
+    throw new BacktestRequestError(message, response.status);
   }
 
   if (!response.body) {
@@ -223,7 +233,7 @@ export const postBacktest = async (
 
   if (!response.ok) {
     const message = resolveProxyErrorMessage(response);
-    throw new Error(message);
+    throw new BacktestRequestError(message, response.status);
   }
 
   if (!response.body) {

--- a/extension/ui/src/api/backtests.dtos.ts
+++ b/extension/ui/src/api/backtests.dtos.ts
@@ -13,6 +13,11 @@ export interface BacktestStatisticsListDto {
   content: BacktestStatisticsDto[];
 }
 
+export interface BacktestLimitsDto {
+  permits: number;
+  expiration: string | number | null;
+}
+
 export interface BacktestCyclesListDto {
   totalElements: number;
   totalPages: number;

--- a/extension/ui/src/api/backtests.ts
+++ b/extension/ui/src/api/backtests.ts
@@ -4,6 +4,7 @@ import type { BacktestsListParams } from '../types/backtests';
 import type {
   BacktestConfigDto,
   BacktestCyclesListDto,
+  BacktestLimitsDto,
   BacktestStatisticsDto,
   BacktestStatisticsListDto,
 } from './backtests.dtos';
@@ -28,6 +29,28 @@ export const fetchBacktests = async (params: BacktestsListParams): Promise<Backt
 
   const response = await proxyHttpRequest<BacktestStatisticsListDto>({
     url,
+    init: {
+      method: 'GET',
+      credentials: 'include',
+    },
+  });
+
+  if (!response.ok) {
+    const errorMessage = resolveProxyErrorMessage(response);
+    throw new Error(errorMessage);
+  }
+
+  const { body } = response;
+  if (!body) {
+    throw new Error('Пустой ответ сервера.');
+  }
+
+  return body;
+};
+
+export const fetchBacktestLimits = async (): Promise<BacktestLimitsDto> => {
+  const response = await proxyHttpRequest<BacktestLimitsDto>({
+    url: `${BACKTESTS_CORE_ENDPOINT}/limits`,
     init: {
       method: 'GET',
       credentials: 'include',

--- a/extension/ui/src/api/users.dtos.ts
+++ b/extension/ui/src/api/users.dtos.ts
@@ -1,0 +1,3 @@
+export interface UserBalanceDto {
+  balance: number;
+}

--- a/extension/ui/src/api/users.ts
+++ b/extension/ui/src/api/users.ts
@@ -1,0 +1,28 @@
+import { proxyHttpRequest } from '../lib/extensionMessaging';
+import { resolveProxyErrorMessage } from '../lib/httpErrors';
+import { buildApiUrl } from './baseUrl';
+import type { UserBalanceDto } from './users.dtos';
+
+const USERS_ENDPOINT = buildApiUrl('/api/users');
+
+export const fetchUserBalance = async (): Promise<UserBalanceDto> => {
+  const response = await proxyHttpRequest<UserBalanceDto>({
+    url: `${USERS_ENDPOINT}/balance`,
+    init: {
+      method: 'GET',
+      credentials: 'include',
+    },
+  });
+
+  if (!response.ok) {
+    const errorMessage = resolveProxyErrorMessage(response);
+    throw new Error(errorMessage);
+  }
+
+  const { body } = response;
+  if (!body) {
+    throw new Error('Пустой ответ сервера.');
+  }
+
+  return body;
+};

--- a/extension/ui/src/components/AppLayout.tsx
+++ b/extension/ui/src/components/AppLayout.tsx
@@ -23,7 +23,9 @@ import { APP_NAME, APP_VERSION } from '../config/version';
 import { useThemeMode } from '../context/ThemeContext';
 import { readStorageValue, writeStorageValue } from '../lib/safeStorage';
 import { backtestsService } from '../services/backtests';
+import { usersService } from '../services/users';
 import type { BacktestLimits } from '../types/backtests';
+import type { UserBalance } from '../types/users';
 import ConnectionHelpModal from './ConnectionHelpModal';
 import SupportProjectModal from './SupportProjectModal';
 import TelegramChannelModal from './TelegramChannelModal';
@@ -54,6 +56,8 @@ const ACCOUNT_STATUS_REFRESH_MS = 5 * 60 * 1000;
 interface AccountStatusSnapshot {
   backtestLimits: BacktestLimits | null;
   backtestLimitsError: string | null;
+  userBalance: UserBalance | null;
+  userBalanceError: string | null;
 }
 
 const formatTimestamp = (timestamp: number | null) => {
@@ -81,6 +85,17 @@ const formatBacktestLimitsStatus = (limits: BacktestLimits | null): string => {
   return `Бесплатно: ${limits.permits} из 10`;
 };
 
+const serviceBalanceFormatter = new Intl.NumberFormat('ru-RU', {
+  maximumFractionDigits: 8,
+});
+
+const formatServiceBalance = (balance: UserBalance | null): string => {
+  if (!balance) {
+    return '—';
+  }
+  return serviceBalanceFormatter.format(balance.balance);
+};
+
 const resolveSelectedKey = (pathname: string, navigationKeys: string[]) => {
   if (!pathname || pathname === '/') {
     return '/';
@@ -101,6 +116,9 @@ const AppLayout = ({ children, extensionReady, connectionStatus, onPing, onOpenV
   const [backtestLimits, setBacktestLimits] = useState<BacktestLimits | null>(null);
   const [backtestLimitsLoading, setBacktestLimitsLoading] = useState(false);
   const [backtestLimitsError, setBacktestLimitsError] = useState<string | null>(null);
+  const [userBalance, setUserBalance] = useState<UserBalance | null>(null);
+  const [userBalanceLoading, setUserBalanceLoading] = useState(false);
+  const [userBalanceError, setUserBalanceError] = useState<string | null>(null);
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -116,6 +134,9 @@ const AppLayout = ({ children, extensionReady, connectionStatus, onPing, onOpenV
       setBacktestLimits(null);
       setBacktestLimitsError(null);
       setBacktestLimitsLoading(false);
+      setUserBalance(null);
+      setUserBalanceError(null);
+      setUserBalanceLoading(false);
       return;
     }
 
@@ -125,23 +146,33 @@ const AppLayout = ({ children, extensionReady, connectionStatus, onPing, onOpenV
       setBacktestLimits(snapshot.backtestLimits);
       setBacktestLimitsError(snapshot.backtestLimitsError);
       setBacktestLimitsLoading(false);
+      setUserBalance(snapshot.userBalance);
+      setUserBalanceError(snapshot.userBalanceError);
+      setUserBalanceLoading(false);
     };
 
     const loadStatus = async () => {
       setBacktestLimitsLoading(true);
       setBacktestLimitsError(null);
+      setUserBalanceLoading(true);
+      setUserBalanceError(null);
       try {
-        const limitsResult = await Promise.resolve(backtestsService.getBacktestLimits()).then(
-          (value) => ({ status: 'fulfilled' as const, value }),
-          (reason) => ({ status: 'rejected' as const, reason }),
-        );
+        const [limitsResult, balanceResult] = await Promise.allSettled([
+          backtestsService.getBacktestLimits(),
+          usersService.getUserBalance(),
+        ]);
         const snapshot: AccountStatusSnapshot = {
           backtestLimits: limitsResult.status === 'fulfilled' ? limitsResult.value : null,
           backtestLimitsError: limitsResult.status === 'rejected' ? 'Не удалось загрузить' : null,
+          userBalance: balanceResult.status === 'fulfilled' ? balanceResult.value : null,
+          userBalanceError: balanceResult.status === 'rejected' ? 'Не удалось загрузить' : null,
         };
 
         if (limitsResult.status === 'rejected') {
           console.warn('[AppLayout] Не удалось загрузить лимиты бэктестов', limitsResult.reason);
+        }
+        if (balanceResult.status === 'rejected') {
+          console.warn('[AppLayout] Не удалось загрузить баланс сервиса', balanceResult.reason);
         }
 
         if (!cancelled) {
@@ -152,10 +183,13 @@ const AppLayout = ({ children, extensionReady, connectionStatus, onPing, onOpenV
         if (!cancelled) {
           setBacktestLimits(null);
           setBacktestLimitsError('Не удалось загрузить');
+          setUserBalance(null);
+          setUserBalanceError('Не удалось загрузить');
         }
       } finally {
         if (!cancelled) {
           setBacktestLimitsLoading(false);
+          setUserBalanceLoading(false);
         }
       }
     };
@@ -297,6 +331,14 @@ const AppLayout = ({ children, extensionReady, connectionStatus, onPing, onOpenV
               {backtestLimitsLoading
                 ? 'Загрузка...'
                 : (backtestLimitsError ?? formatBacktestLimitsStatus(backtestLimits))}
+            </Tag>
+          </div>
+          <div className="app-layout__status-row">
+            <Typography.Text type="secondary" className="app-layout__status-label">
+              Баланс сервиса
+            </Typography.Text>
+            <Tag color="processing">
+              {userBalanceLoading ? 'Загрузка...' : (userBalanceError ?? formatServiceBalance(userBalance))}
             </Tag>
           </div>
         </div>

--- a/extension/ui/src/components/AppLayout.tsx
+++ b/extension/ui/src/components/AppLayout.tsx
@@ -22,6 +22,8 @@ import logo from '../assets/logo.png';
 import { APP_NAME, APP_VERSION } from '../config/version';
 import { useThemeMode } from '../context/ThemeContext';
 import { readStorageValue, writeStorageValue } from '../lib/safeStorage';
+import { backtestsService } from '../services/backtests';
+import type { BacktestLimits } from '../types/backtests';
 import ConnectionHelpModal from './ConnectionHelpModal';
 import SupportProjectModal from './SupportProjectModal';
 import TelegramChannelModal from './TelegramChannelModal';
@@ -47,12 +49,36 @@ const AUTHOR_URL = 'https://t.me/dontsov';
 const CHROME_WEBSTORE_URL = 'https://chromewebstore.google.com/detail/veles-tools/hgfhapnhcnncjplmjkbbljhjpcjilbgm';
 const TELEGRAM_CHANNEL_URL = 'https://t.me/veles_tools';
 const TELEGRAM_MODAL_KEY = '__VELES_TG_CHANNEL_SHOWN';
+const ACCOUNT_STATUS_REFRESH_MS = 5 * 60 * 1000;
+
+interface AccountStatusSnapshot {
+  backtestLimits: BacktestLimits | null;
+  backtestLimitsError: string | null;
+}
 
 const formatTimestamp = (timestamp: number | null) => {
   if (!timestamp) {
     return '—';
   }
   return new Date(timestamp).toLocaleTimeString();
+};
+
+const formatBacktestLimitsExpiration = (expiration: Date): string => {
+  return expiration.toLocaleDateString('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+};
+
+const formatBacktestLimitsStatus = (limits: BacktestLimits | null): string => {
+  if (!limits) {
+    return '—';
+  }
+  if (limits.hasActiveSubscription && limits.expiration) {
+    return `Активна до ${formatBacktestLimitsExpiration(limits.expiration)}`;
+  }
+  return `Бесплатно: ${limits.permits} из 10`;
 };
 
 const resolveSelectedKey = (pathname: string, navigationKeys: string[]) => {
@@ -72,6 +98,9 @@ const AppLayout = ({ children, extensionReady, connectionStatus, onPing, onOpenV
   const [supportModalOpen, setSupportModalOpen] = useState(false);
   const [telegramModalOpen, setTelegramModalOpen] = useState(false);
   const [connectionHelpOpen, setConnectionHelpOpen] = useState(false);
+  const [backtestLimits, setBacktestLimits] = useState<BacktestLimits | null>(null);
+  const [backtestLimitsLoading, setBacktestLimitsLoading] = useState(false);
+  const [backtestLimitsError, setBacktestLimitsError] = useState<string | null>(null);
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -81,6 +110,66 @@ const AppLayout = ({ children, extensionReady, connectionStatus, onPing, onOpenV
       writeStorageValue(TELEGRAM_MODAL_KEY, 'shown');
     }
   }, []);
+
+  useEffect(() => {
+    if (!extensionReady || !connectionStatus.ok) {
+      setBacktestLimits(null);
+      setBacktestLimitsError(null);
+      setBacktestLimitsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const applySnapshot = (snapshot: AccountStatusSnapshot) => {
+      setBacktestLimits(snapshot.backtestLimits);
+      setBacktestLimitsError(snapshot.backtestLimitsError);
+      setBacktestLimitsLoading(false);
+    };
+
+    const loadStatus = async () => {
+      setBacktestLimitsLoading(true);
+      setBacktestLimitsError(null);
+      try {
+        const limitsResult = await Promise.resolve(backtestsService.getBacktestLimits()).then(
+          (value) => ({ status: 'fulfilled' as const, value }),
+          (reason) => ({ status: 'rejected' as const, reason }),
+        );
+        const snapshot: AccountStatusSnapshot = {
+          backtestLimits: limitsResult.status === 'fulfilled' ? limitsResult.value : null,
+          backtestLimitsError: limitsResult.status === 'rejected' ? 'Не удалось загрузить' : null,
+        };
+
+        if (limitsResult.status === 'rejected') {
+          console.warn('[AppLayout] Не удалось загрузить лимиты бэктестов', limitsResult.reason);
+        }
+
+        if (!cancelled) {
+          applySnapshot(snapshot);
+        }
+      } catch (error) {
+        console.warn('[AppLayout] Не удалось загрузить статус аккаунта', error);
+        if (!cancelled) {
+          setBacktestLimits(null);
+          setBacktestLimitsError('Не удалось загрузить');
+        }
+      } finally {
+        if (!cancelled) {
+          setBacktestLimitsLoading(false);
+        }
+      }
+    };
+
+    void loadStatus();
+    const refreshTimer = window.setInterval(() => {
+      void loadStatus();
+    }, ACCOUNT_STATUS_REFRESH_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(refreshTimer);
+    };
+  }, [connectionStatus.ok, connectionStatus.origin, extensionReady]);
 
   const navigationItems = [
     {
@@ -199,6 +288,18 @@ const AppLayout = ({ children, extensionReady, connectionStatus, onPing, onOpenV
             description="Откройте интерфейс из меню расширения для работы с запросами."
           />
         )}
+        <div className="app-layout__status-panel">
+          <div className="app-layout__status-row">
+            <Typography.Text type="secondary" className="app-layout__status-label">
+              Бэктесты
+            </Typography.Text>
+            <Tag color={backtestLimits?.hasActiveSubscription ? 'success' : 'default'}>
+              {backtestLimitsLoading
+                ? 'Загрузка...'
+                : (backtestLimitsError ?? formatBacktestLimitsStatus(backtestLimits))}
+            </Tag>
+          </div>
+        </div>
         <div className="app-layout__sider-footer">
           <Space direction="vertical" size={8}>
             <Typography.Link href={CHROME_WEBSTORE_URL} target="_blank" rel="noreferrer noopener">

--- a/extension/ui/src/components/BacktestModal.tsx
+++ b/extension/ui/src/components/BacktestModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Progress } from 'antd';
+import { Button, Progress, Select } from 'antd';
 import {
   type ChangeEvent,
   type FormEvent,
@@ -11,6 +11,7 @@ import {
 } from 'react';
 import {
   type BacktestApiVersion,
+  BacktestRequestError,
   type BotStrategy,
   buildBacktestPayload,
   composeSymbol,
@@ -19,6 +20,7 @@ import {
   resolveQuoteCurrency,
   type SymbolDescriptor,
 } from '../api/backtestRunner';
+import { useBacktestGroups } from '../context/BacktestGroupsContext';
 import { useImportedBots } from '../context/ImportedBotsContext';
 import { parseAssetList } from '../lib/assetList';
 import { buildCabinetUrl } from '../lib/cabinetUrls';
@@ -26,6 +28,7 @@ import { applyBotNameTemplate } from '../lib/nameTemplate';
 import { useDocumentTitle } from '../lib/useDocumentTitle';
 import { readMultiCurrencyAssetList, writeMultiCurrencyAssetList } from '../storage/backtestPreferences';
 import type { BotSummary } from '../types/bots';
+import type { BacktestGroup } from '../types/backtestGroups';
 
 export type BacktestVariant = 'single' | 'multiCurrency';
 
@@ -36,7 +39,11 @@ interface FormErrors {
   makerCommission?: string;
   takerCommission?: string;
   assetList?: string;
+  targetGroupName?: string;
+  targetGroupId?: string;
 }
+
+type BacktestGroupTargetMode = 'none' | 'existing' | 'new';
 
 interface BacktestFormState {
   nameTemplate: string;
@@ -47,6 +54,15 @@ interface BacktestFormState {
   isPublic: boolean;
   includeWicks: boolean;
   assetList: string;
+  targetGroupMode: BacktestGroupTargetMode;
+  targetGroupId: string;
+  targetGroupName: string;
+}
+
+interface BacktestGroupTarget {
+  mode: BacktestGroupTargetMode;
+  groupId: string | null;
+  groupName: string | null;
 }
 
 interface BacktestLaunchPayload {
@@ -61,6 +77,7 @@ interface BacktestLaunchPayload {
   includeWicks: boolean;
   assetList: string[];
   apiVersion: BacktestApiVersion;
+  groupTarget: BacktestGroupTarget;
 }
 
 interface BacktestModalProps {
@@ -88,10 +105,14 @@ const defaultFormState: BacktestFormState = {
   isPublic: false,
   includeWicks: true,
   assetList: '',
+  targetGroupMode: 'none',
+  targetGroupId: '',
+  targetGroupName: '',
 };
 
 const V1_BACKTEST_DELAY_MS = 31_000;
 const V2_BACKTEST_DELAY_MS = 5_000;
+const RATE_LIMIT_RETRY_DELAY_MS = 10_000;
 
 const retainDigits = (value: string) => value.replace(/[^0-9.,]/g, '');
 
@@ -215,6 +236,16 @@ const wait = (ms: number) =>
     window.setTimeout(resolve, ms);
   });
 
+const isRateLimitError = (error: unknown): boolean => {
+  if (error instanceof BacktestRequestError && error.status === 429) {
+    return true;
+  }
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return /\b429\b/.test(error.message) || error.message.toLowerCase().includes('too many requests');
+};
+
 const BacktestModal = ({ variant, selectedBots, onClose }: BacktestModalProps) => {
   const [formState, setFormState] = useState<BacktestFormState>(() => ({
     ...defaultFormState,
@@ -231,6 +262,7 @@ const BacktestModal = ({ variant, selectedBots, onClose }: BacktestModalProps) =
   const logContainerRef = useRef<HTMLDivElement | null>(null);
   const { getInitialTitle, setTitle: setDocumentTitle, resetTitle } = useDocumentTitle();
   const { getStrategyById } = useImportedBots();
+  const { groups, createGroup, appendToGroup } = useBacktestGroups();
 
   useEffect(() => {
     isActiveRef.current = true;
@@ -334,6 +366,30 @@ const BacktestModal = ({ variant, selectedBots, onClose }: BacktestModalProps) =
     }));
   };
 
+  const handleGroupModeChange = (value: BacktestGroupTargetMode) => {
+    setFormState((prev) => ({
+      ...prev,
+      targetGroupMode: value,
+      targetGroupId: value === 'existing' ? (prev.targetGroupId || groups[0]?.id || '') : prev.targetGroupId,
+    }));
+    setFormErrors((prev) => ({
+      ...prev,
+      targetGroupId: undefined,
+      targetGroupName: undefined,
+    }));
+  };
+
+  const handleGroupIdChange = (value: string) => {
+    setFormState((prev) => ({
+      ...prev,
+      targetGroupId: value,
+    }));
+    setFormErrors((prev) => ({
+      ...prev,
+      targetGroupId: undefined,
+    }));
+  };
+
   const handleCheckboxChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { name, checked } = event.target;
     setFormState((prev) => ({
@@ -375,6 +431,13 @@ const BacktestModal = ({ variant, selectedBots, onClose }: BacktestModalProps) =
         }
       }
 
+      if (state.targetGroupMode === 'existing' && !state.targetGroupId) {
+        errors.targetGroupId = 'Выберите группу';
+      }
+      if (state.targetGroupMode === 'new' && state.targetGroupName.trim().length === 0) {
+        errors.targetGroupName = 'Введите название группы';
+      }
+
       return errors;
     },
     [variant],
@@ -393,6 +456,11 @@ const BacktestModal = ({ variant, selectedBots, onClose }: BacktestModalProps) =
       includeWicks: state.includeWicks,
       assetList: variant === 'multiCurrency' ? parseAssetList(state.assetList) : [],
       apiVersion: 'v1',
+      groupTarget: {
+        mode: state.targetGroupMode,
+        groupId: state.targetGroupMode === 'existing' ? state.targetGroupId : null,
+        groupName: state.targetGroupMode === 'new' ? state.targetGroupName.trim() : null,
+      },
     }),
     [selectedBots, variant],
   );
@@ -426,6 +494,84 @@ const BacktestModal = ({ variant, selectedBots, onClose }: BacktestModalProps) =
           }
           const safeCompleted = Math.min(completed, plannedTotal);
           setProgress(Math.round((safeCompleted / plannedTotal) * 100));
+        };
+
+        let resolvedTargetGroup: BacktestGroup | null =
+          payload.groupTarget.mode === 'existing' && payload.groupTarget.groupId
+            ? (groups.find((group) => group.id === payload.groupTarget.groupId) ?? null)
+            : null;
+
+        const addBacktestToTargetGroup = (backtestId: number) => {
+          if (payload.groupTarget.mode === 'none') {
+            return;
+          }
+
+          if (payload.groupTarget.mode === 'existing') {
+            if (!payload.groupTarget.groupId) {
+              appendLog(`⚠️ Бэктест ${backtestId} не добавлен в группу: группа не выбрана.`);
+              return;
+            }
+            const updatedGroup = appendToGroup(payload.groupTarget.groupId, [backtestId]);
+            if (!updatedGroup) {
+              appendLog(`⚠️ Бэктест ${backtestId} не добавлен в группу: группа недоступна.`);
+              return;
+            }
+            resolvedTargetGroup = updatedGroup;
+            return;
+          }
+
+          if (!payload.groupTarget.groupName) {
+            appendLog(`⚠️ Бэктест ${backtestId} не добавлен в группу: не указано название группы.`);
+            return;
+          }
+
+          if (!resolvedTargetGroup) {
+            const createdGroup = createGroup(payload.groupTarget.groupName, [backtestId]);
+            if (!createdGroup) {
+              appendLog(`⚠️ Бэктест ${backtestId} не добавлен в новую группу.`);
+              return;
+            }
+            resolvedTargetGroup = createdGroup;
+            appendLog(`Группа «${createdGroup.name}» создана.`);
+            return;
+          }
+
+          const updatedGroup = appendToGroup(resolvedTargetGroup.id, [backtestId]);
+          if (!updatedGroup) {
+            appendLog(`⚠️ Бэктест ${backtestId} не добавлен в группу «${resolvedTargetGroup.name}».`);
+            return;
+          }
+          resolvedTargetGroup = updatedGroup;
+        };
+
+        const postBacktestWithRateLimitRetry = async (
+          body: BotStrategy,
+          version: BacktestApiVersion,
+          backtestName: string,
+          logId: string | null,
+        ) => {
+          let attempt = 1;
+          while (isActiveRef.current) {
+            try {
+              return await postBacktest(body, version);
+            } catch (error) {
+              if (!isRateLimitError(error)) {
+                throw error;
+              }
+
+              const retryNode = `⏳ «${backtestName}»: получен 429, повтор через 10 секунд (попытка ${attempt + 1})`;
+              if (logId) {
+                replaceLog(logId, retryNode);
+              } else {
+                appendLog(retryNode);
+              }
+
+              attempt += 1;
+              await wait(RATE_LIMIT_RETRY_DELAY_MS);
+            }
+          }
+
+          return null;
         };
 
         if (payload.variant === 'multiCurrency' && assets.length === 0) {
@@ -522,8 +668,19 @@ const BacktestModal = ({ variant, selectedBots, onClose }: BacktestModalProps) =
                   periodEndISO: endISO,
                   overrideSymbol: descriptor,
                 });
-                const response = await postBacktest(body, payload.apiVersion);
+                const response = await postBacktestWithRateLimitRetry(
+                  body,
+                  payload.apiVersion,
+                  backtestName,
+                  pendingId,
+                );
+                if (!response) {
+                  return;
+                }
                 const backtestId = typeof response.id === 'number' ? response.id : '—';
+                if (typeof response.id === 'number') {
+                  addBacktestToTargetGroup(response.id);
+                }
                 const backtestUrl =
                   typeof response.id === 'number' ? buildCabinetUrl(`backtests/${response.id}`) : null;
                 const successNode = backtestUrl ? (
@@ -595,8 +752,14 @@ const BacktestModal = ({ variant, selectedBots, onClose }: BacktestModalProps) =
                 periodEndISO: endISO,
                 overrideSymbol: descriptor,
               });
-              const response = await postBacktest(body);
+              const response = await postBacktestWithRateLimitRetry(body, payload.apiVersion, backtestName, logId);
+              if (!response) {
+                return;
+              }
               const backtestId = typeof response.id === 'number' ? response.id : '—';
+              if (typeof response.id === 'number') {
+                addBacktestToTargetGroup(response.id);
+              }
               const backtestUrl = typeof response.id === 'number' ? buildCabinetUrl(`backtests/${response.id}`) : null;
               if (logId) {
                 replaceLog(
@@ -829,6 +992,60 @@ const BacktestModal = ({ variant, selectedBots, onClose }: BacktestModalProps) =
               <span>Учитывать тени свечей</span>
             </label>
           </div>
+
+          <div className="form-field">
+            <label className="form-label" htmlFor="backtest-target-group-mode">
+              Группа бэктестов
+            </label>
+            <Select<BacktestGroupTargetMode>
+              id="backtest-target-group-mode"
+              value={formState.targetGroupMode}
+              onChange={handleGroupModeChange}
+              disabled={isRunning}
+              options={[
+                { label: 'Не добавлять в группу', value: 'none' },
+                { label: 'Добавить в существующую', value: 'existing', disabled: groups.length === 0 },
+                { label: 'Создать новую группу', value: 'new' },
+              ]}
+            />
+          </div>
+
+          {formState.targetGroupMode === 'existing' && (
+            <div className="form-field">
+              <label className="form-label" htmlFor="backtest-target-group-id">
+                Выберите группу
+              </label>
+              <Select
+                id="backtest-target-group-id"
+                value={formState.targetGroupId || undefined}
+                onChange={handleGroupIdChange}
+                disabled={isRunning}
+                status={formErrors.targetGroupId ? 'error' : undefined}
+                placeholder="Группа"
+                options={groups.map((group) => ({ label: group.name, value: group.id }))}
+              />
+              {formErrors.targetGroupId && <span className="form-error">{formErrors.targetGroupId}</span>}
+            </div>
+          )}
+
+          {formState.targetGroupMode === 'new' && (
+            <div className="form-field">
+              <label className="form-label" htmlFor="backtest-target-group-name">
+                Название новой группы
+              </label>
+              <input
+                id="backtest-target-group-name"
+                name="targetGroupName"
+                type="text"
+                className={`input ${formErrors.targetGroupName ? 'input--error' : ''}`}
+                value={formState.targetGroupName}
+                onChange={handleTextChange}
+                placeholder="Например: Майские бэктесты"
+                disabled={isRunning}
+              />
+              {formErrors.targetGroupName && <span className="form-error">{formErrors.targetGroupName}</span>}
+            </div>
+          )}
 
           {variant === 'multiCurrency' && (
             <div className="form-field">

--- a/extension/ui/src/components/BacktestModal.tsx
+++ b/extension/ui/src/components/BacktestModal.tsx
@@ -867,223 +867,225 @@ const BacktestModal = ({ variant, selectedBots, onClose }: BacktestModalProps) =
         </header>
 
         <form className="modal__form" onSubmit={handleSubmit}>
-          <div className="form-field">
-            <label className="form-label" htmlFor="backtest-name">
-              Название бэктеста
-            </label>
-            <input
-              id="backtest-name"
-              name="nameTemplate"
-              type="text"
-              className={`input ${formErrors.nameTemplate ? 'input--error' : ''}`}
-              value={formState.nameTemplate}
-              onChange={handleTextChange}
-              placeholder="Например: {bot_name} backtest"
-              disabled={isRunning}
-            />
-            <span className="form-hint">Можно использовать плейсхолдеры {placeholderExample}</span>
-            {formErrors.nameTemplate && <span className="form-error">{formErrors.nameTemplate}</span>}
-          </div>
-
-          <div className="form-grid">
+          <div className="modal__body">
             <div className="form-field">
-              <label className="form-label" htmlFor="backtest-period-from">
-                Дата начала
+              <label className="form-label" htmlFor="backtest-name">
+                Название бэктеста
               </label>
               <input
-                id="backtest-period-from"
-                name="periodFrom"
-                type="date"
-                className={`input ${formErrors.periodFrom ? 'input--error' : ''}`}
-                value={formState.periodFrom}
-                onChange={handleTextChange}
-                disabled={isRunning}
-              />
-              {formErrors.periodFrom && <span className="form-error">{formErrors.periodFrom}</span>}
-            </div>
-
-            <div className="form-field">
-              <label className="form-label" htmlFor="backtest-period-to">
-                Дата окончания
-              </label>
-              <input
-                id="backtest-period-to"
-                name="periodTo"
-                type="date"
-                className={`input ${formErrors.periodTo ? 'input--error' : ''}`}
-                value={formState.periodTo}
-                onChange={handleTextChange}
-                disabled={isRunning}
-              />
-              {formErrors.periodTo && <span className="form-error">{formErrors.periodTo}</span>}
-            </div>
-          </div>
-
-          <div className="form-presets">
-            <span className="form-presets__label">Быстрый период:</span>
-            {periodPresets.map((preset) => (
-              <Button
-                key={preset.months}
-                className="form-preset-button"
-                size="small"
-                onClick={() => handlePresetClick(preset.months)}
-                disabled={isRunning}
-              >
-                {preset.label}
-              </Button>
-            ))}
-          </div>
-
-          <div className="form-grid">
-            <div className="form-field">
-              <label className="form-label" htmlFor="maker-commission">
-                Комиссия мейкера
-              </label>
-              <input
-                id="maker-commission"
-                name="makerCommission"
+                id="backtest-name"
+                name="nameTemplate"
                 type="text"
-                inputMode="decimal"
-                className={`input ${formErrors.makerCommission ? 'input--error' : ''}`}
-                value={formState.makerCommission}
+                className={`input ${formErrors.nameTemplate ? 'input--error' : ''}`}
+                value={formState.nameTemplate}
                 onChange={handleTextChange}
+                placeholder="Например: {bot_name} backtest"
                 disabled={isRunning}
               />
-              {formErrors.makerCommission && <span className="form-error">{formErrors.makerCommission}</span>}
+              <span className="form-hint">Можно использовать плейсхолдеры {placeholderExample}</span>
+              {formErrors.nameTemplate && <span className="form-error">{formErrors.nameTemplate}</span>}
             </div>
 
-            <div className="form-field">
-              <label className="form-label" htmlFor="taker-commission">
-                Комиссия тейкера
-              </label>
-              <input
-                id="taker-commission"
-                name="takerCommission"
-                type="text"
-                inputMode="decimal"
-                className={`input ${formErrors.takerCommission ? 'input--error' : ''}`}
-                value={formState.takerCommission}
-                onChange={handleTextChange}
-                disabled={isRunning}
-              />
-              {formErrors.takerCommission && <span className="form-error">{formErrors.takerCommission}</span>}
-            </div>
-          </div>
-
-          <div className="form-checkboxes">
-            <label className="checkbox-field">
-              <input
-                type="checkbox"
-                name="isPublic"
-                checked={formState.isPublic}
-                onChange={handleCheckboxChange}
-                disabled={isRunning}
-              />
-              <span>Публичный бэктест</span>
-            </label>
-            <label className="checkbox-field">
-              <input
-                type="checkbox"
-                name="includeWicks"
-                checked={formState.includeWicks}
-                onChange={handleCheckboxChange}
-                disabled={isRunning}
-              />
-              <span>Учитывать тени свечей</span>
-            </label>
-          </div>
-
-          <div className="form-field">
-            <label className="form-label" htmlFor="backtest-target-group-mode">
-              Группа бэктестов
-            </label>
-            <Select<BacktestGroupTargetMode>
-              id="backtest-target-group-mode"
-              value={formState.targetGroupMode}
-              onChange={handleGroupModeChange}
-              disabled={isRunning}
-              options={[
-                { label: 'Не добавлять в группу', value: 'none' },
-                { label: 'Добавить в существующую', value: 'existing', disabled: groups.length === 0 },
-                { label: 'Создать новую группу', value: 'new' },
-              ]}
-            />
-          </div>
-
-          {formState.targetGroupMode === 'existing' && (
-            <div className="form-field">
-              <label className="form-label" htmlFor="backtest-target-group-id">
-                Выберите группу
-              </label>
-              <Select
-                id="backtest-target-group-id"
-                value={formState.targetGroupId || undefined}
-                onChange={handleGroupIdChange}
-                disabled={isRunning}
-                status={formErrors.targetGroupId ? 'error' : undefined}
-                placeholder="Группа"
-                options={groups.map((group) => ({ label: group.name, value: group.id }))}
-              />
-              {formErrors.targetGroupId && <span className="form-error">{formErrors.targetGroupId}</span>}
-            </div>
-          )}
-
-          {formState.targetGroupMode === 'new' && (
-            <div className="form-field">
-              <label className="form-label" htmlFor="backtest-target-group-name">
-                Название новой группы
-              </label>
-              <input
-                id="backtest-target-group-name"
-                name="targetGroupName"
-                type="text"
-                className={`input ${formErrors.targetGroupName ? 'input--error' : ''}`}
-                value={formState.targetGroupName}
-                onChange={handleTextChange}
-                placeholder="Например: Майские бэктесты"
-                disabled={isRunning}
-              />
-              {formErrors.targetGroupName && <span className="form-error">{formErrors.targetGroupName}</span>}
-            </div>
-          )}
-
-          {variant === 'multiCurrency' && (
-            <div className="form-field">
-              <label className="form-label" htmlFor="asset-list">
-                Список валют
-              </label>
-              <textarea
-                id="asset-list"
-                name="assetList"
-                className={`textarea ${formErrors.assetList ? 'textarea--error' : ''}`}
-                rows={3}
-                placeholder="Например: BTC, ETH, SOL"
-                value={formState.assetList}
-                onChange={handleTextChange}
-                disabled={isRunning}
-              />
-              <span className="form-hint">Разделитель — пробел, запятая или перенос строки</span>
-              {formErrors.assetList && <span className="form-error">{formErrors.assetList}</span>}
-            </div>
-          )}
-
-          {logs.length > 0 && (
-            <div className="run-log">
-              <div className="run-log__progress modal-progress">
-                <Progress percent={progress} size="small" showInfo={false} />
-                <span className="progress-bar__label">{progress}%</span>
+            <div className="form-grid">
+              <div className="form-field">
+                <label className="form-label" htmlFor="backtest-period-from">
+                  Дата начала
+                </label>
+                <input
+                  id="backtest-period-from"
+                  name="periodFrom"
+                  type="date"
+                  className={`input ${formErrors.periodFrom ? 'input--error' : ''}`}
+                  value={formState.periodFrom}
+                  onChange={handleTextChange}
+                  disabled={isRunning}
+                />
+                {formErrors.periodFrom && <span className="form-error">{formErrors.periodFrom}</span>}
               </div>
-              <div className="run-log__messages" role="log" aria-live="polite" ref={logContainerRef}>
-                {logs.map((entry) => (
-                  <div key={entry.id} className="run-log__entry">
-                    {entry.node}
-                  </div>
-                ))}
+
+              <div className="form-field">
+                <label className="form-label" htmlFor="backtest-period-to">
+                  Дата окончания
+                </label>
+                <input
+                  id="backtest-period-to"
+                  name="periodTo"
+                  type="date"
+                  className={`input ${formErrors.periodTo ? 'input--error' : ''}`}
+                  value={formState.periodTo}
+                  onChange={handleTextChange}
+                  disabled={isRunning}
+                />
+                {formErrors.periodTo && <span className="form-error">{formErrors.periodTo}</span>}
               </div>
             </div>
-          )}
 
-          {runError && <div className="banner banner--warning">{runError}</div>}
+            <div className="form-presets">
+              <span className="form-presets__label">Быстрый период:</span>
+              {periodPresets.map((preset) => (
+                <Button
+                  key={preset.months}
+                  className="form-preset-button"
+                  size="small"
+                  onClick={() => handlePresetClick(preset.months)}
+                  disabled={isRunning}
+                >
+                  {preset.label}
+                </Button>
+              ))}
+            </div>
+
+            <div className="form-grid">
+              <div className="form-field">
+                <label className="form-label" htmlFor="maker-commission">
+                  Комиссия мейкера
+                </label>
+                <input
+                  id="maker-commission"
+                  name="makerCommission"
+                  type="text"
+                  inputMode="decimal"
+                  className={`input ${formErrors.makerCommission ? 'input--error' : ''}`}
+                  value={formState.makerCommission}
+                  onChange={handleTextChange}
+                  disabled={isRunning}
+                />
+                {formErrors.makerCommission && <span className="form-error">{formErrors.makerCommission}</span>}
+              </div>
+
+              <div className="form-field">
+                <label className="form-label" htmlFor="taker-commission">
+                  Комиссия тейкера
+                </label>
+                <input
+                  id="taker-commission"
+                  name="takerCommission"
+                  type="text"
+                  inputMode="decimal"
+                  className={`input ${formErrors.takerCommission ? 'input--error' : ''}`}
+                  value={formState.takerCommission}
+                  onChange={handleTextChange}
+                  disabled={isRunning}
+                />
+                {formErrors.takerCommission && <span className="form-error">{formErrors.takerCommission}</span>}
+              </div>
+            </div>
+
+            <div className="form-checkboxes">
+              <label className="checkbox-field">
+                <input
+                  type="checkbox"
+                  name="isPublic"
+                  checked={formState.isPublic}
+                  onChange={handleCheckboxChange}
+                  disabled={isRunning}
+                />
+                <span>Публичный бэктест</span>
+              </label>
+              <label className="checkbox-field">
+                <input
+                  type="checkbox"
+                  name="includeWicks"
+                  checked={formState.includeWicks}
+                  onChange={handleCheckboxChange}
+                  disabled={isRunning}
+                />
+                <span>Учитывать тени свечей</span>
+              </label>
+            </div>
+
+            <div className="form-field">
+              <label className="form-label" htmlFor="backtest-target-group-mode">
+                Группа бэктестов
+              </label>
+              <Select<BacktestGroupTargetMode>
+                id="backtest-target-group-mode"
+                value={formState.targetGroupMode}
+                onChange={handleGroupModeChange}
+                disabled={isRunning}
+                options={[
+                  { label: 'Не добавлять в группу', value: 'none' },
+                  { label: 'Добавить в существующую', value: 'existing', disabled: groups.length === 0 },
+                  { label: 'Создать новую группу', value: 'new' },
+                ]}
+              />
+            </div>
+
+            {formState.targetGroupMode === 'existing' && (
+              <div className="form-field">
+                <label className="form-label" htmlFor="backtest-target-group-id">
+                  Выберите группу
+                </label>
+                <Select
+                  id="backtest-target-group-id"
+                  value={formState.targetGroupId || undefined}
+                  onChange={handleGroupIdChange}
+                  disabled={isRunning}
+                  status={formErrors.targetGroupId ? 'error' : undefined}
+                  placeholder="Группа"
+                  options={groups.map((group) => ({ label: group.name, value: group.id }))}
+                />
+                {formErrors.targetGroupId && <span className="form-error">{formErrors.targetGroupId}</span>}
+              </div>
+            )}
+
+            {formState.targetGroupMode === 'new' && (
+              <div className="form-field">
+                <label className="form-label" htmlFor="backtest-target-group-name">
+                  Название новой группы
+                </label>
+                <input
+                  id="backtest-target-group-name"
+                  name="targetGroupName"
+                  type="text"
+                  className={`input ${formErrors.targetGroupName ? 'input--error' : ''}`}
+                  value={formState.targetGroupName}
+                  onChange={handleTextChange}
+                  placeholder="Например: Майские бэктесты"
+                  disabled={isRunning}
+                />
+                {formErrors.targetGroupName && <span className="form-error">{formErrors.targetGroupName}</span>}
+              </div>
+            )}
+
+            {variant === 'multiCurrency' && (
+              <div className="form-field">
+                <label className="form-label" htmlFor="asset-list">
+                  Список валют
+                </label>
+                <textarea
+                  id="asset-list"
+                  name="assetList"
+                  className={`textarea ${formErrors.assetList ? 'textarea--error' : ''}`}
+                  rows={3}
+                  placeholder="Например: BTC, ETH, SOL"
+                  value={formState.assetList}
+                  onChange={handleTextChange}
+                  disabled={isRunning}
+                />
+                <span className="form-hint">Разделитель — пробел, запятая или перенос строки</span>
+                {formErrors.assetList && <span className="form-error">{formErrors.assetList}</span>}
+              </div>
+            )}
+
+            {logs.length > 0 && (
+              <div className="run-log">
+                <div className="run-log__progress modal-progress">
+                  <Progress percent={progress} size="small" showInfo={false} />
+                  <span className="progress-bar__label">{progress}%</span>
+                </div>
+                <div className="run-log__messages" role="log" aria-live="polite" ref={logContainerRef}>
+                  {logs.map((entry) => (
+                    <div key={entry.id} className="run-log__entry">
+                      {entry.node}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {runError && <div className="banner banner--warning">{runError}</div>}
+          </div>
 
           <footer className="modal__footer">
             <Button onClick={handleCancel}>{isRunning ? 'Отменить' : isCompleted ? 'Закрыть' : 'Отмена'}</Button>

--- a/extension/ui/src/context/BacktestGroupsContext.tsx
+++ b/extension/ui/src/context/BacktestGroupsContext.tsx
@@ -52,6 +52,7 @@ export const BacktestGroupsProvider = ({ children }: PropsWithChildren) => {
       if (trimmedName.length === 0 || normalizedIds.length === 0) {
         return null;
       }
+      const currentGroups = readBacktestGroups();
       const timestamp = Date.now();
       const group: BacktestGroup = {
         id: generateGroupId(),
@@ -60,10 +61,10 @@ export const BacktestGroupsProvider = ({ children }: PropsWithChildren) => {
         createdAt: timestamp,
         updatedAt: timestamp,
       };
-      persist([...groups, group]);
+      persist([...currentGroups, group]);
       return group;
     },
-    [groups, persist],
+    [persist],
   );
 
   const appendToGroup = useCallback(
@@ -76,9 +77,10 @@ export const BacktestGroupsProvider = ({ children }: PropsWithChildren) => {
         return null;
       }
 
+      const currentGroups = readBacktestGroups();
       let updatedGroup: BacktestGroup | null = null;
       let changed = false;
-      const nextGroups = groups.map((group) => {
+      const nextGroups = currentGroups.map((group) => {
         if (group.id !== groupId) {
           return group;
         }
@@ -105,7 +107,7 @@ export const BacktestGroupsProvider = ({ children }: PropsWithChildren) => {
       }
       return updatedGroup;
     },
-    [groups, persist],
+    [persist],
   );
 
   const updateGroupName = useCallback(

--- a/extension/ui/src/pages/BacktestGroupDetailsPage.tsx
+++ b/extension/ui/src/pages/BacktestGroupDetailsPage.tsx
@@ -1,5 +1,5 @@
 import type { MenuProps } from 'antd';
-import { Alert, Button, Card, Dropdown, Empty, Input, Modal, message, Progress, Radio, Select } from 'antd';
+import { Alert, Button, Card, Dropdown, Empty, Input, Modal, message, Progress, Radio, Select, Tag } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import BacktestAggregationConfigPanel from '../components/backtests/BacktestAggregationConfigPanel';
@@ -11,7 +11,7 @@ import PageHeader from '../components/ui/PageHeader';
 import { useBacktestGroups } from '../context/BacktestGroupsContext';
 import type { LimitImpactPoint } from '../lib/chartOptions';
 import { aggregateBacktestsMetrics, DEFAULT_AGGREGATION_CONFIG } from '../services/backtestAggregations';
-import { buildBacktestInfo } from '../services/backtestInfos';
+import { buildBacktestInfo, collectUniqueBacktestCoins } from '../services/backtestInfos';
 import { backtestsService } from '../services/backtests';
 import { readAggregationConfig, writeAggregationConfig } from '../storage/backtestAggregationConfigStore';
 import { readLimitAnalysisPreferences, writeLimitAnalysisPreferences } from '../storage/backtestLimitAnalysisStore';
@@ -41,6 +41,7 @@ const isCompleteSource = (source: CachedBacktestSource): source is CompleteBackt
 };
 
 const DEFAULT_LIMIT_IMPACT_VALUE = 5;
+const MAX_VISIBLE_SELECTED_COINS = 24;
 
 const BacktestGroupDetailsPage = ({ extensionReady }: BacktestGroupDetailsPageProps) => {
   const { groupId } = useParams<{ groupId: string }>();
@@ -346,6 +347,9 @@ const BacktestGroupDetailsPage = ({ extensionReady }: BacktestGroupDetailsPagePr
     const selectedSet = new Set(selectedIds);
     return backtestInfos.filter((info) => selectedSet.has(info.id));
   }, [backtestInfos, selectedIds]);
+  const selectedCoins = useMemo(() => collectUniqueBacktestCoins(selectedBacktests), [selectedBacktests]);
+  const visibleSelectedCoins = selectedCoins.slice(0, MAX_VISIBLE_SELECTED_COINS);
+  const hiddenSelectedCoinsCount = Math.max(0, selectedCoins.length - visibleSelectedCoins.length);
 
   const aggregatedMetrics = useMemo<AggregatedBacktestsMetrics | null>(() => {
     if (selectedBacktests.length === 0) {
@@ -710,6 +714,15 @@ const BacktestGroupDetailsPage = ({ extensionReady }: BacktestGroupDetailsPagePr
             <p className="panel__description">
               Загружено {loadedCount} из {totalBacktests} · выбрано {selectedCount}
             </p>
+            {selectedCoins.length > 0 && (
+              <div className="u-mt-8">
+                <span className="panel__description">Монеты выбранных бэктестов: </span>
+                {visibleSelectedCoins.map((coin) => (
+                  <Tag key={coin}>{coin}</Tag>
+                ))}
+                {hiddenSelectedCoinsCount > 0 && <Tag>+{hiddenSelectedCoinsCount}</Tag>}
+              </div>
+            )}
           </div>
         </div>
 

--- a/extension/ui/src/services/__tests__/backtestInfos.test.ts
+++ b/extension/ui/src/services/__tests__/backtestInfos.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { BacktestConfigDto } from '../../api/backtests.dtos';
 import type { BacktestCycle, BacktestDetail, BacktestOrder, BacktestStatistics } from '../../types/backtests';
-import { buildBacktestInfo } from '../backtestInfos';
+import { buildBacktestInfo, collectUniqueBacktestCoins } from '../backtestInfos';
 
 const baseConfig: BacktestConfigDto = {
   id: 1,
@@ -275,5 +275,35 @@ describe('buildBacktestInfo', () => {
 
     const info = buildBacktestInfo(detail, cycles);
     expect(info.tradingDays).toBe(3);
+  });
+});
+
+describe('collectUniqueBacktestCoins', () => {
+  it('returns sorted unique base coins for selected backtests', () => {
+    const btcInfo = buildBacktestInfo(createDetail(), []);
+    const ethInfo = buildBacktestInfo(
+      createDetail({
+        statistics: {
+          ...baseStatistics,
+          id: 2,
+          symbol: 'ETHUSDT',
+          base: 'ETH',
+        },
+      }),
+      [],
+    );
+    const duplicatedBtcInfo = buildBacktestInfo(
+      createDetail({
+        statistics: {
+          ...baseStatistics,
+          id: 3,
+          symbol: 'BTCUSDT',
+          base: 'BTC',
+        },
+      }),
+      [],
+    );
+
+    expect(collectUniqueBacktestCoins([ethInfo, btcInfo, duplicatedBtcInfo])).toEqual(['BTC', 'ETH']);
   });
 });

--- a/extension/ui/src/services/backtestInfos.ts
+++ b/extension/ui/src/services/backtestInfos.ts
@@ -168,3 +168,16 @@ export const buildBacktestInfo = (detail: BacktestDetail, cycles: BacktestCycle[
     deals,
   };
 };
+
+export const collectUniqueBacktestCoins = (backtests: BacktestInfo[]): string[] => {
+  const coins = new Set<string>();
+
+  backtests.forEach((backtest) => {
+    const coin = backtest.base.trim();
+    if (coin.length > 0) {
+      coins.add(coin);
+    }
+  });
+
+  return Array.from(coins).sort((left, right) => left.localeCompare(right, 'en', { sensitivity: 'base' }));
+};

--- a/extension/ui/src/services/backtests.ts
+++ b/extension/ui/src/services/backtests.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_CYCLES_PAGE_SIZE,
+  fetchBacktestLimits,
   fetchBacktestConfig,
   fetchBacktestCycles,
   fetchBacktestStatistics,
@@ -19,6 +20,7 @@ import {
 import type {
   BacktestCycle,
   BacktestDetail,
+  BacktestLimits,
   BacktestStatistics,
   BacktestStatisticsListResponse,
   BacktestsListParams,
@@ -41,6 +43,11 @@ export interface BacktestCyclesRequest extends GetBacktestCyclesOptions {
   to?: string | null;
 }
 
+const ACCOUNT_STATUS_CACHE_TTL_MS = 5 * 60 * 1000;
+let backtestLimitsCache: { value: BacktestLimits; fetchedAt: number } | null = null;
+let backtestLimitsErrorCache: { error: Error; fetchedAt: number } | null = null;
+let backtestLimitsRequest: Promise<BacktestLimits> | null = null;
+
 export const getBacktestsList = async (params: BacktestsListParams): Promise<BacktestStatisticsListResponse> => {
   const dto = await fetchBacktests(params);
   return {
@@ -49,6 +56,62 @@ export const getBacktestsList = async (params: BacktestsListParams): Promise<Bac
     pageNumber: dto.pageNumber,
     content: mapStatisticsListFromDto(dto.content ?? []),
   };
+};
+
+const parseBacktestLimitExpiration = (value: string | number | null): Date | null => {
+  if (value === null) {
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    const timestamp = value > 10_000_000_000 ? value : value * 1000;
+    const date = new Date(timestamp);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    return null;
+  }
+
+  return new Date(timestamp);
+};
+
+export const getBacktestLimits = async (): Promise<BacktestLimits> => {
+  const now = Date.now();
+  if (backtestLimitsCache && now - backtestLimitsCache.fetchedAt < ACCOUNT_STATUS_CACHE_TTL_MS) {
+    return backtestLimitsCache.value;
+  }
+  if (backtestLimitsErrorCache && now - backtestLimitsErrorCache.fetchedAt < ACCOUNT_STATUS_CACHE_TTL_MS) {
+    throw backtestLimitsErrorCache.error;
+  }
+  if (backtestLimitsRequest) {
+    return backtestLimitsRequest;
+  }
+
+  backtestLimitsRequest = fetchBacktestLimits()
+    .then((dto) => {
+      const expiration = parseBacktestLimitExpiration(dto.expiration);
+      const limits: BacktestLimits = {
+        permits: dto.permits,
+        expiration,
+        hasActiveSubscription: expiration !== null && expiration.getTime() > Date.now(),
+      };
+
+      backtestLimitsCache = { value: limits, fetchedAt: Date.now() };
+      backtestLimitsErrorCache = null;
+      return limits;
+    })
+    .catch((error) => {
+      const normalizedError = error instanceof Error ? error : new Error(String(error));
+      backtestLimitsErrorCache = { error: normalizedError, fetchedAt: Date.now() };
+      throw normalizedError;
+    })
+    .finally(() => {
+      backtestLimitsRequest = null;
+    });
+
+  return backtestLimitsRequest;
 };
 
 export const getBacktestDetail = async (
@@ -137,6 +200,7 @@ export const getBacktestCycles = async (id: number, params: BacktestCyclesReques
 
 export const backtestsService = {
   getBacktestsList,
+  getBacktestLimits,
   getBacktestDetail,
   getBacktestCycles,
   readCachedBacktestDetail,

--- a/extension/ui/src/services/users.ts
+++ b/extension/ui/src/services/users.ts
@@ -1,0 +1,47 @@
+import { fetchUserBalance } from '../api/users';
+import type { UserBalance } from '../types/users';
+
+const ACCOUNT_STATUS_CACHE_TTL_MS = 5 * 60 * 1000;
+let userBalanceCache: { value: UserBalance; fetchedAt: number } | null = null;
+let userBalanceErrorCache: { error: Error; fetchedAt: number } | null = null;
+let userBalanceRequest: Promise<UserBalance> | null = null;
+
+export const getUserBalance = async (): Promise<UserBalance> => {
+  const now = Date.now();
+  if (userBalanceCache && now - userBalanceCache.fetchedAt < ACCOUNT_STATUS_CACHE_TTL_MS) {
+    return userBalanceCache.value;
+  }
+  if (userBalanceErrorCache && now - userBalanceErrorCache.fetchedAt < ACCOUNT_STATUS_CACHE_TTL_MS) {
+    throw userBalanceErrorCache.error;
+  }
+  if (userBalanceRequest) {
+    return userBalanceRequest;
+  }
+
+  userBalanceRequest = fetchUserBalance()
+    .then((dto) => {
+      const balance: UserBalance = {
+        balance: dto.balance,
+      };
+
+      userBalanceCache = { value: balance, fetchedAt: Date.now() };
+      userBalanceErrorCache = null;
+      return balance;
+    })
+    .catch((error) => {
+      const normalizedError = error instanceof Error ? error : new Error(String(error));
+      userBalanceErrorCache = { error: normalizedError, fetchedAt: Date.now() };
+      throw normalizedError;
+    })
+    .finally(() => {
+      userBalanceRequest = null;
+    });
+
+  return userBalanceRequest;
+};
+
+export const usersService = {
+  getUserBalance,
+};
+
+export type UsersService = typeof usersService;

--- a/extension/ui/src/styles.css
+++ b/extension/ui/src/styles.css
@@ -1022,20 +1022,21 @@ body {
   position: relative;
   width: min(760px, 92vw);
   max-height: 92vh;
-  overflow-y: auto;
+  overflow: hidden;
   background-color: var(--ant-color-bg-container, #fff);
   border-radius: 20px;
-  padding: 24px 28px;
   box-shadow: 0 20px 50px rgba(15, 23, 42, 0.25);
   display: flex;
   flex-direction: column;
-  gap: 20px;
 }
 
 .modal__header {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  padding: 24px 28px 16px;
+  border-bottom: 1px solid var(--ant-color-border, #e2e8f0);
+  flex: 0 0 auto;
 }
 
 .modal__title {
@@ -1052,7 +1053,17 @@ body {
 .modal__form {
   display: flex;
   flex-direction: column;
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
+.modal__body {
+  display: flex;
+  flex-direction: column;
   gap: 16px;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 20px 28px;
 }
 
 .form-field {
@@ -1209,6 +1220,9 @@ body {
   display: flex;
   justify-content: flex-end;
   gap: 12px;
+  padding: 16px 28px 24px;
+  border-top: 1px solid var(--ant-color-border, #e2e8f0);
+  flex: 0 0 auto;
 }
 
 .modal__aside {

--- a/extension/ui/src/styles.css
+++ b/extension/ui/src/styles.css
@@ -93,6 +93,33 @@ body {
   margin-top: 24px;
 }
 
+.app-layout__status-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 16px;
+  padding: 12px;
+  border: 1px solid var(--ant-color-border, #e2e8f0);
+  border-radius: 8px;
+  background-color: var(--ant-color-fill-alter, #f8fafc);
+}
+
+.app-layout__status-label {
+  font-size: 12px;
+}
+
+.app-layout__status-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.app-layout__status-panel .ant-tag {
+  width: fit-content;
+  max-width: 100%;
+  white-space: normal;
+}
+
 .app-layout__sider-footer {
   margin-top: auto;
   padding-top: 16px;

--- a/extension/ui/src/types/backtests.ts
+++ b/extension/ui/src/types/backtests.ts
@@ -25,5 +25,11 @@ export interface BacktestStatisticsListResponse {
   content: BacktestStatistics[];
 }
 
+export interface BacktestLimits {
+  permits: number;
+  expiration: Date | null;
+  hasActiveSubscription: boolean;
+}
+
 export type BacktestCycle = BacktestCycleDto;
 export type BacktestOrder = BacktestOrderDto;

--- a/extension/ui/src/types/users.ts
+++ b/extension/ui/src/types/users.ts
@@ -1,0 +1,3 @@
+export interface UserBalance {
+  balance: number;
+}


### PR DESCRIPTION
## Summary
- add beta.veles.finance extension support
- show selected backtest coins, subscription status, and service balance
- improve backtest launch flow with 429 retry handling and group assignment
- keep backtest modal header/footer fixed while the body scrolls

Refs: #26

## Verification
- npm test -- backtestRunner
- npm run typecheck
- npm run build