### PR TITLE
fix(backtests): prevent instant deals from blocking aggregation

### DIFF
--- a/extension/ui/src/services/__tests__/backtestAggregations.test.ts
+++ b/extension/ui/src/services/__tests__/backtestAggregations.test.ts
@@ -344,4 +344,32 @@ describe('aggregateBacktestsMetrics', () => {
     expect(metrics.activeDealCountSeries.at(-1)).toEqual({ date: end, value: 0 });
     expect(metrics.maxConcurrentPositions).toBe(2);
   });
+
+  it('does not let instant (zero-duration) deals occupy a concurrency slot forever', () => {
+    // A stop-loss that triggers in the same candle it opened produces a deal with start === end.
+    // It must not stay "active" and block every later deal (which truncated the aggregated chart).
+    const instant = toTimestamp('2024-07-01T00:00:00Z');
+    const laterStart = toTimestamp('2024-07-05T00:00:00Z');
+    const laterEnd = toTimestamp('2024-07-05T06:00:00Z');
+    const deals = [
+      buildDeal({ id: 'instant', start: instant, end: instant, net: -5 }),
+      buildDeal({ id: 'later', start: laterStart, end: laterEnd, net: 30 }),
+    ];
+
+    const metrics = aggregateBacktestsMetrics([buildInfo({ id: 20 }, deals)], {
+      maxConcurrentPositions: 1,
+      positionBlocking: false,
+    });
+
+    // Both deals are counted (the later one is NOT blocked by a phantom instant deal).
+    expect(metrics.totalProfitQuote).toBe(25);
+    expect(metrics.totalProfitableDeals).toBe(1);
+    expect(metrics.totalLosingDeals).toBe(1);
+    expect(metrics.maxConcurrentPositions).toBe(1);
+    // The instant deal does not leave a permanent open position.
+    expect(metrics.openDeals).toBe(0);
+    // The P&L series reaches the last real deal's close, not the instant deal's timestamp.
+    expect(metrics.pnlSeries.at(-1)).toEqual({ date: laterEnd, value: 25 });
+    expect(metrics.dealTimelineRows[0]?.items.every((item) => item.limitedByConcurrency === false)).toBe(true);
+  });
 });

--- a/extension/ui/src/services/backtestAggregations.ts
+++ b/extension/ui/src/services/backtestAggregations.ts
@@ -134,6 +134,24 @@ export const aggregateBacktestsMetrics = (
       // biome-ignore lint/style/noNonNullAssertion: checked above
       const potentialDeal = sortedDealsCopy.shift()!;
 
+      // Instant deals (open and close within the same time point, e.g. a stop-loss that triggers
+      // in the same candle it opened) must not be added to activeDeals: the closing pass for this
+      // time point has already run, so they would otherwise stay "active" forever and permanently
+      // consume a concurrency slot, blocking every later deal. Finalize them immediately instead.
+      if (potentialDeal.end <= timePoint) {
+        dealsResults.push({ deal: potentialDeal, used: true });
+        if (potentialDeal.status !== 'STARTED') {
+          aggregatedStats.totalNet += potentialDeal.net;
+          aggregatedStats.pnlSeries.push({ date: timePoint, value: aggregatedStats.totalNet });
+          if (potentialDeal.net >= 0) {
+            aggregatedStats.deals.profit += 1;
+          } else {
+            aggregatedStats.deals.loss += 1;
+          }
+        }
+        continue;
+      }
+
       let blocked = activeDeals.length >= limit;
 
       if (!blocked && positionBlocking) {


### PR DESCRIPTION
## Проблема

В агрегации бектестов график P&L портфеля «не доходил до конца» — обрывался на месяцы раньше реального конца периода, а суммы занижались. Зависело от лимита одновременных позиций, хотя при числе бектестов меньше лимита блокировки быть не должно.

## Причина

В `aggregateBacktestsMetrics` на каждой временной точке сначала закрываются сделки (`end === timePoint`), потом открываются (`start === timePoint`). Сделка с `start === end` (мгновенный стоп-лосс — buy и SL в одну минуту/свечу, `duration: null`) добавляется в `activeDeals` уже **после** фазы закрытия этой точки. Её `end` больше никогда не встретится → она навсегда висит как открытая, занимая слот одновременности и блокируя все последующие сделки.

Подтверждено на реальных данных (XRPUSDT + SOLUSDT): у SOL две такие сделки → при низком лимите график обрывался на ~2025-08, intrinsic concurrency раздувался с 1 до 3. P&L этих сделок при этом терялся.

## Фикс

Мгновенные сделки (`end <= timePoint`) финализируются сразу: учитываются в P&L и win/loss, но не кладутся в `activeDeals` и не блокируются лимитом.

## Проверки

- Регресс-тест на мгновенные сделки.
- Тесты 80/80, typecheck, lint, build — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)