### PR TITLE
feat(backtests): configurable launch delay for v2 backtests

### DIFF
--- a/extension/ui/src/components/BacktestModal.tsx
+++ b/extension/ui/src/components/BacktestModal.tsx
@@ -26,6 +26,7 @@ import { parseAssetList } from '../lib/assetList';
 import { buildCabinetUrl } from '../lib/cabinetUrls';
 import { applyBotNameTemplate } from '../lib/nameTemplate';
 import { useDocumentTitle } from '../lib/useDocumentTitle';
+import { DEFAULT_V2_BACKTEST_DELAY_MS, readBacktestV2LaunchDelay } from '../storage/backtestLaunchDelayStore';
 import { readMultiCurrencyAssetList, writeMultiCurrencyAssetList } from '../storage/backtestPreferences';
 import type { BacktestGroup } from '../types/backtestGroups';
 import type { BotSummary } from '../types/bots';
@@ -111,7 +112,6 @@ const defaultFormState: BacktestFormState = {
 };
 
 const V1_BACKTEST_DELAY_MS = 31_000;
-const V2_BACKTEST_DELAY_MS = 5_000;
 const RATE_LIMIT_RETRY_DELAY_MS = 10_000;
 
 const retainDigits = (value: string) => value.replace(/[^0-9.,]/g, '');
@@ -475,7 +475,10 @@ const BacktestModal = ({ variant, selectedBots, onClose }: BacktestModalProps) =
 
       try {
         const { startISO, endISO } = toIsoRange(payload.periodFrom, payload.periodTo);
-        const launchDelayMs = payload.apiVersion === 'v2' ? V2_BACKTEST_DELAY_MS : V1_BACKTEST_DELAY_MS;
+        const launchDelayMs =
+          payload.apiVersion === 'v2'
+            ? (readBacktestV2LaunchDelay() ?? DEFAULT_V2_BACKTEST_DELAY_MS)
+            : V1_BACKTEST_DELAY_MS;
 
         const assets = payload.variant === 'multiCurrency' ? payload.assetList : [];
         const plannedTotal =

--- a/extension/ui/src/pages/SettingsPage.tsx
+++ b/extension/ui/src/pages/SettingsPage.tsx
@@ -4,6 +4,12 @@ import { useDealsRefresh } from '../context/DealsRefreshContext';
 import { useRequestDelay } from '../context/RequestDelayContext';
 import type { ActiveDealsRefreshInterval } from '../lib/activeDealsPolling';
 import { clearBacktestCache } from '../storage/backtestCache';
+import {
+  DEFAULT_V2_BACKTEST_DELAY_MS,
+  normalizeBacktestV2LaunchDelay,
+  readBacktestV2LaunchDelay,
+  writeBacktestV2LaunchDelay,
+} from '../storage/backtestLaunchDelayStore';
 import { normalizeRequestDelay } from '../storage/requestDelayStore';
 
 const SettingsPage = () => {
@@ -13,6 +19,8 @@ const SettingsPage = () => {
   const [requestDelayDraft, setRequestDelayDraft] = useState<number>(delayMs);
   const { refreshInterval: dealsRefreshInterval, setRefreshInterval, defaultInterval, options } = useDealsRefresh();
   const [dealsRefreshDraft, setDealsRefreshDraft] = useState<ActiveDealsRefreshInterval>(dealsRefreshInterval);
+  const [v2DelayMs, setV2DelayMs] = useState<number>(() => readBacktestV2LaunchDelay() ?? DEFAULT_V2_BACKTEST_DELAY_MS);
+  const [v2DelayDraft, setV2DelayDraft] = useState<number>(v2DelayMs);
 
   useEffect(() => {
     setRequestDelayDraft(delayMs);
@@ -71,9 +79,35 @@ const SettingsPage = () => {
     setDelayMs(defaultDelayMs);
   };
 
+  const handleV2DelayChange = (value: number | null) => {
+    setV2DelayDraft(value ?? 0);
+  };
+
+  const handleV2DelayBlur = () => {
+    setV2DelayDraft((prev) => normalizeBacktestV2LaunchDelay(prev));
+  };
+
+  const handleV2DelaySave = () => {
+    setV2DelayDraft((prev) => {
+      const saved = writeBacktestV2LaunchDelay(prev);
+      setV2DelayMs(saved);
+      return saved;
+    });
+  };
+
+  const handleV2DelayReset = () => {
+    const saved = writeBacktestV2LaunchDelay(DEFAULT_V2_BACKTEST_DELAY_MS);
+    setV2DelayDraft(saved);
+    setV2DelayMs(saved);
+  };
+
   const normalizedDraft = normalizeRequestDelay(requestDelayDraft);
   const saveDisabled = normalizedDraft === delayMs;
   const resetDisabled = delayMs === defaultDelayMs && normalizedDraft === defaultDelayMs;
+  const normalizedV2Draft = normalizeBacktestV2LaunchDelay(v2DelayDraft);
+  const v2SaveDisabled = normalizedV2Draft === v2DelayMs;
+  const v2ResetDisabled =
+    v2DelayMs === DEFAULT_V2_BACKTEST_DELAY_MS && normalizedV2Draft === DEFAULT_V2_BACKTEST_DELAY_MS;
   const dealsSaveDisabled = dealsRefreshDraft === dealsRefreshInterval;
   const dealsResetDisabled = dealsRefreshInterval === defaultInterval && dealsRefreshDraft === defaultInterval;
 
@@ -115,6 +149,36 @@ const SettingsPage = () => {
             </Space>
             <Typography.Text type="secondary">
               Новое значение применяется немедленно и сохраняется в локальном хранилище.
+            </Typography.Text>
+          </Space>
+        </Card>
+
+        <Card title="Задержка между запуском бектестов (v2)" bordered>
+          <Space direction="vertical" size={16} className="u-full-width">
+            <Typography.Paragraph className="u-mb-0">
+              Пауза между последовательными запусками бектестов через API v2. По умолчанию —{' '}
+              {DEFAULT_V2_BACKTEST_DELAY_MS} мс. Если часто получаете ответ 429 (Too Many Requests) при запуске,
+              увеличьте значение.
+            </Typography.Paragraph>
+            <Space size={12} align="center" wrap>
+              <InputNumber
+                min={0}
+                step={500}
+                value={v2DelayDraft}
+                onChange={handleV2DelayChange}
+                onBlur={handleV2DelayBlur}
+                onPressEnter={handleV2DelaySave}
+                addonAfter="мс"
+              />
+              <Button type="primary" onClick={handleV2DelaySave} disabled={v2SaveDisabled}>
+                Сохранить
+              </Button>
+              <Button onClick={handleV2DelayReset} disabled={v2ResetDisabled}>
+                Сбросить к {DEFAULT_V2_BACKTEST_DELAY_MS} мс
+              </Button>
+            </Space>
+            <Typography.Text type="secondary">
+              Применяется при следующем запуске. Влияет только на API v2.
             </Typography.Text>
           </Space>
         </Card>

--- a/extension/ui/src/storage/backtestLaunchDelayStore.ts
+++ b/extension/ui/src/storage/backtestLaunchDelayStore.ts
@@ -1,0 +1,38 @@
+import { readStorageValue, writeStorageValue } from '../lib/safeStorage';
+
+const STORAGE_KEY = 'veles-tools.backtest.v2LaunchDelayMs';
+
+export const DEFAULT_V2_BACKTEST_DELAY_MS = 5_000;
+
+const sanitizeDelayValue = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return DEFAULT_V2_BACKTEST_DELAY_MS;
+  }
+
+  const normalized = Math.round(value);
+  return normalized >= 0 ? normalized : DEFAULT_V2_BACKTEST_DELAY_MS;
+};
+
+export const readBacktestV2LaunchDelay = (): number | null => {
+  const raw = readStorageValue(STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  return sanitizeDelayValue(parsed);
+};
+
+export const writeBacktestV2LaunchDelay = (delayMs: number): number => {
+  const sanitized = sanitizeDelayValue(delayMs);
+  writeStorageValue(STORAGE_KEY, String(sanitized));
+  return sanitized;
+};
+
+export const normalizeBacktestV2LaunchDelay = (candidate: number): number => {
+  return sanitizeDelayValue(candidate);
+};


### PR DESCRIPTION
## Что

Добавлено поле в настройках для кастомной задержки между последовательными запусками бектестов через API v2. Раньше — хардкод 5000 мс.

## Изменения

- **`storage/backtestLaunchDelayStore.ts`** (новый) — стор по образцу `requestDelayStore`: read/write/normalize, default 5000 мс, ключ `veles-tools.backtest.v2LaunchDelayMs`, санитайз (целое ≥ 0).
- **`BacktestModal.tsx`** — задержка v2 читается из стора (`?? DEFAULT`) в момент запуска; хардкод-константа убрана. v1 (31с) без изменений.
- **`SettingsPage.tsx`** — новая карточка «Задержка между запуском бектестов (v2)»: `InputNumber` + Сохранить/Сбросить, как у задержки запросов.

Применяется со следующего запуска.

## Проверки

typecheck, lint, build, тесты 80/80 — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)